### PR TITLE
Laravel 7

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.github                export-ignore
+/tests                  export-ignore
+.editorconfig           export-ignore
+.gitattributes          export-ignore
+.gitignore              export-ignore
+phpunit.xml.dist        export-ignore

--- a/composer.json
+++ b/composer.json
@@ -8,21 +8,26 @@
             "email": "hekmati.nasser@gmail.com"
         }
     ],
-    "keywords": ["Laravel","Date","Datetime","Jalali", "Shamsi", "Verta"],
+    "keywords": [
+        "Laravel",
+        "Date",
+        "Datetime",
+        "Jalali",
+        "Shamsi",
+        "Verta"
+    ],
     "require": {
-        "php": "^7.3|^8.0|^8.1",
-        "illuminate/support": "^6.0|^8.0|^9.0",
-        "illuminate/validation": "^6.0|^8.0|^9.0",
+        "php": "^7.3|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/validation": "^6.0|^7.0|^8.0|^9.0",
         "hekmatinasser/notowo": "^1.0"
     },
-    "require-dev" : {
-        "orchestra/testbench": "^4.9|^6.23|^7.0",
-        "phpunit/phpunit": "^9.4",
-        "mockery/mockery": "^1.0"
+    "require-dev": {
+        "orchestra/testbench": "^4.18|^5.20|^6.24|^7.0"
     },
     "autoload": {
         "psr-4": {
-            "Hekmatinasser\\Verta\\": "src"
+            "Hekmatinasser\\Verta\\": "src/"
         },
         "files": [
             "src/helpers.php"
@@ -30,10 +35,9 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Hekmatinasser\\VertaTests\\": "tests"
+            "Hekmatinasser\\Verta\\Tests\\": "tests/"
         }
     },
-    "minimum-stability": "dev",
     "extra": {
         "laravel": {
             "providers": [
@@ -43,5 +47,7 @@
                 "Verta": "Hekmatinasser\\Verta\\Verta"
             }
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
- Add laravel 7 support
- Removed ^8.1 because ^8.0 will support 8.1 too
- Set dependencies config to prefer stable
- Fixed tests classes namespace (PSR-4)
- Removed phpunit (it's inside orchestra)
- Add editor config for consistent indentation
- Export ignore unnecessary files so it won't be downloaded when someone installs package with composer

I think /docs folder must be added to gitattributes. 🤔 