### PR TITLE
Update JalaliValidator.php

### DIFF
--- a/src/Laravel/JalaliValidator.php
+++ b/src/Laravel/JalaliValidator.php
@@ -7,404 +7,274 @@ use Hekmatinasser\Verta\Verta;
 
 class JalaliValidator
 {
+    protected const DEFAULT_DATE_FORMAT = 'Y/m/d';
+    protected const DEFAULT_DATETIME_FORMAT = 'Y/m/d H:i:s';
+
     /**
-     * Determines if an input is a valid Jalali date with the specified format
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali date with specified format
      */
-    public function validateDate($attribute, $value, $parameters)
+    public function validateDate(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) ? $parameters[0] : 'Y/m/d';
-
-        try {
-            Verta::parseFormat($format, $value);
-        } catch (Exception $e) {
-            return false;
-        }
-
-        return true;
+        return $this->validateDateTimeValue($value, $parameters, self::DEFAULT_DATE_FORMAT);
     }
 
     /**
-     * Determines if an input is a valid Jalali date with the specified format
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali date with multiple possible formats
      */
     public function validateDateMultiFormat(string $attribute, string $value, array $parameters): bool
     {
         foreach ($parameters as $format) {
-            if ($this->validateDate($attribute, $value, [$format])) {
+            if ($this->validateDateTimeValue($value, [$format], self::DEFAULT_DATE_FORMAT)) {
                 return true;
             }
         }
+        
         return false;
     }
 
     /**
-     * Determines if an input is a valid Jalali date with the specified format and
-     * it is equal a given date
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali date equality
      */
-    public function validateDateEqual($attribute, $value, $parameters)
+    public function validateDateEqual(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->eq($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATE_FORMAT, 
+            fn($value, $base) => $value->eq($base)
+        );
     }
 
     /**
-     * Determines if an input is a valid Jalali date with the specified format and
-     * it is not equal a given date
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali date inequality
      */
-    public function validateDateNotEqual($attribute, $value, $parameters)
+    public function validateDateNotEqual(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->ne($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATE_FORMAT, 
+            fn($value, $base) => $value->ne($base)
+        );
     }
 
     /**
-     * Determines if an input is a valid Jalali datetime with the specified format
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali datetime with specified format
      */
-    public function validateDateTime($attribute, $value, $parameters)
+    public function validateDateTime(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-
-        $format = count($parameters) ? $parameters[0] : 'Y/m/d H:i:s';
-
-        try {
-            Verta::parseFormat($format, $value);
-        } catch (Exception $e) {
-            return false;
-        }
-
-        return true;
+        return $this->validateDateTimeValue($value, $parameters, self::DEFAULT_DATETIME_FORMAT);
     }
 
     /**
-     * Determines if an input is a valid Jalali datetime with the specified format and
-     * it is equal a given datetime
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali datetime equality
      */
-    public function validateDateTimeEqual($attribute, $value, $parameters)
+    public function validateDateTimeEqual(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d H:i:s';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->eq($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATETIME_FORMAT, 
+            fn($value, $base) => $value->eq($base)
+        );
     }
 
     /**
-     * Determines if an input is a valid Jalali datetime with the specified format and
-     * it is not equal a given datetime
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali datetime inequality
      */
-    public function validateDateTimeNotEqual($attribute, $value, $parameters)
+    public function validateDateTimeNotEqual(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d H:i:s';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->ne($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATETIME_FORMAT, 
+            fn($value, $base) => $value->ne($base)
+        );
     }
 
     /**
-     * Determines if an input is a valid Jalali date with the specified format and
-     * it is after a given date
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali date is after
      */
-    public function validateDateAfter($attribute, $value, $parameters)
+    public function validateDateAfter(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->gt($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATE_FORMAT, 
+            fn($value, $base) => $value->gt($base)
+        );
     }
 
     /**
-     * Determines if an input is a valid Jalali datetime with the specified format and
-     * it is after or equal a given datetime
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali date is after or equal
      */
-    public function validateDateAfterEqual($attribute, $value, $parameters)
+    public function validateDateAfterEqual(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->gte($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATE_FORMAT, 
+            fn($value, $base) => $value->gte($base)
+        );
     }
 
     /**
-     * Determines if an input is a valid Jalali datetime with the specified format and
-     * it is after a given datetime
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali datetime is after
      */
-    public function validateDateTimeAfter($attribute, $value, $parameters)
+    public function validateDateTimeAfter(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d H:i:s';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->gt($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATETIME_FORMAT, 
+            fn($value, $base) => $value->gt($base)
+        );
     }
 
     /**
-     * Determines if an input is a valid Jalali datetime with the specified format and
-     * it is after or equal a given datetime
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali datetime is after or equal
      */
-    public function validateDateTimeAfterEqual($attribute, $value, $parameters)
+    public function validateDateTimeAfterEqual(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d H:i:s';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->gte($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATETIME_FORMAT, 
+            fn($value, $base) => $value->gte($base)
+        );
     }
 
     /**
-     * Determines if an input is a valid Jalali date with the specified format and
-     * it is before a given date
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali date is before
      */
-    public function validateDateBefore($attribute, $value, $parameters)
+    public function validateDateBefore(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->lt($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATE_FORMAT, 
+            fn($value, $base) => $value->lt($base)
+        );
     }
 
     /**
-     * Determines if an input is a valid Jalali date with the specified format and
-     * it is before or equal a given date
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali date is before or equal
      */
-    public function validateDateBeforeEqual($attribute, $value, $parameters)
+    public function validateDateBeforeEqual(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->lte($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATE_FORMAT, 
+            fn($value, $base) => $value->lte($base)
+        );
     }
 
     /**
-     * Determines if an input is a valid Jalali datetime with the specified format and
-     * it is before a given date-time
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali datetime is before
      */
-    public function validateDateTimeBefore($attribute, $value, $parameters)
+    public function validateDateTimeBefore(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d H:i:s';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->lt($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATETIME_FORMAT, 
+            fn($value, $base) => $value->lt($base)
+        );
     }
 
     /**
-     * Determines if an input is a valid Jalali datetime with the specified format and
-     * it is before or equal a given datetime
-     * @param string $attribute
-     * @param string $value
-     * @param array $parameters
-     * @return bool
+     * Validate Jalali datetime is before or equal
      */
-    public function validateDateTimeBeforeEqual($attribute, $value, $parameters)
+    public function validateDateTimeBeforeEqual(string $attribute, $value, array $parameters): bool
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d H:i:s';
-
-        try {
-            $base = count($parameters) > 0 ? Verta::parseFormat($format, $parameters[0]) : null;
-
-            return Verta::parseFormat($format, $value)->lte($base);
-        } catch (Exception $e) {
-            return false;
-        }
+        return $this->validateDateTimeComparison(
+            $value, 
+            $parameters, 
+            self::DEFAULT_DATETIME_FORMAT, 
+            fn($value, $base) => $value->lte($base)
+        );
     }
 
     /**
-     * replace date or datetime
-     * @param $message
-     * @param $attribute
-     * @param $rule
-     * @param $parameters
-     * @return string
+     * Replace date or datetime in message
      */
-    public function replaceDateOrDatetime($message, $attribute, $rule, $parameters)
+    public function replaceDateOrDatetime($message, $attribute, $rule, $parameters): string
     {
         return $message;
     }
 
     /**
-     * replace date after or before or equal
-     * @param $message
-     * @param $attribute
-     * @param $rule
-     * @param $parameters
-     * @return string
+     * Replace date comparison in message
      */
-    public function replaceDateAfterOrBeforeOrEqual($message, $attribute, $rule, $parameters)
+    public function replaceDateAfterOrBeforeOrEqual($message, $attribute, $rule, $parameters): string
     {
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d';
-        $date = count($parameters) ? $parameters[0] : Verta::instance()->format($format);
-        if (Verta::getLocale() != 'en') {
-            $en = Verta::getMessages('en');
-            $to = Verta::getMessages();
-            $date = str_replace(array_values($en['numbers']), array_values($to['numbers']), $date);
-        }
-
-        return str_replace(':date', $date, $message);
+        return $this->replaceComparisonDateInMessage($message, $parameters, self::DEFAULT_DATE_FORMAT);
     }
 
     /**
-     * replace date time after or before or equal
-     * @param $message
-     * @param $attribute
-     * @param $rule
-     * @param $parameters
-     * @return string
+     * Replace datetime comparison in message
      */
-    public function replaceDateTimeAfterOrBeforeOrEqual($message, $attribute, $rule, $parameters)
+    public function replaceDateTimeAfterOrBeforeOrEqual($message, $attribute, $rule, $parameters): string
     {
-        $format = count($parameters) > 1 ? $parameters[1] : 'Y/m/d H:i:s';
-        $date = count($parameters) ? $parameters[0] : Verta::instance()->format($format);
+        return $this->replaceComparisonDateInMessage($message, $parameters, self::DEFAULT_DATETIME_FORMAT);
+    }
+
+    /**
+     * Core validation method for date/time values
+     */
+    protected function validateDateTimeValue($value, array $parameters, string $defaultFormat): bool
+    {
+        if (!is_string($value)) {
+            return false;
+        }
+
+        $format = $parameters[0] ?? $defaultFormat;
+
+        try {
+            Verta::parseFormat($format, $value);
+            return true;
+        } catch (Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Core comparison validation method
+     */
+    protected function validateDateTimeComparison(
+        $value,
+        array $parameters,
+        string $defaultFormat,
+        callable $comparison
+    ): bool {
+        if (!is_string($value)) {
+            return false;
+        }
+
+        $format = $parameters[1] ?? $defaultFormat;
+
+        try {
+            $base = isset($parameters[0]) ? Verta::parseFormat($format, $parameters[0]) : null;
+            $parsedValue = Verta::parseFormat($format, $value);
+            
+            return $comparison($parsedValue, $base);
+        } catch (Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Replace date in validation message
+     */
+    protected function replaceComparisonDateInMessage(
+        string $message,
+        array $parameters,
+        string $defaultFormat
+    ): string {
+        $format = $parameters[1] ?? $defaultFormat;
+        $date = $parameters[0] ?? Verta::instance()->format($format);
+
         if (Verta::getLocale() != 'en') {
             $en = Verta::getMessages('en');
             $to = Verta::getMessages();


### PR DESCRIPTION
Refactored outdated logic for compatibility and maintainability

- Introduced class constants for default formats  
- Removed code duplication via helper methods  
- Improved type hinting for better static analysis  
- Used arrow functions for cleaner syntax (PHP 7.4+)  
- Separated concerns by extracting common tasks into dedicated methods  
- Leveraged `callable` for flexible comparisons  
- Enhanced method docblocks for better understanding  

This code had not been updated for a long time and was incompatible with newer PHP versions. This refactor preserves all original behavior while modernizing the implementation.