### PR TITLE
Fix incorrect `@param null` docblock on `verta()` helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,11 +1,12 @@
 <?php
 
+use Hekmatinasser\Jalali\Jalali;
 use Hekmatinasser\Verta\Verta;
 
 if (! function_exists('verta')) {
     /**
-     * @param null $datetime
-     * @param null $timezone
+     * @param  Jalali|DateTime|string|int|null  $datetime
+     * @param  DateTimeZone|string|null  $timezone
      * @return Verta
      */
     function verta($datetime = null, $timezone = null): Verta


### PR DESCRIPTION
The `verta()` helper in `src/helpers.php` documents both parameters as accepting only `null`:

```php
/**
 * @param null $datetime
 * @param null $timezone
 * @return Verta
 */
function verta($datetime = null, $timezone = null): Verta
```

This doesn't match reality — the function just forwards to new Verta($datetime, $timezone), and Verta extends Jalali, whose constructor (and its own resolve() docblock) accepts Jalali|DateTime|string|int|null for the datetime and DateTimeZone|string|null for the timezone. Calling verta($someDateString) or verta($carbonInstance) works fine at runtime, but the incorrect docblock makes static analysis tools (PHPStan/Larastan) flag every call site that passes an actual datetime value as a type error, even though the code is correct.